### PR TITLE
Delete checking line break for JSCS

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -74,7 +74,6 @@
   "requirePaddingNewLinesAfterBlocks": true,
   "requireSemicolons": true,
   "safeContextKeyword": "_this",
-  "validateLineBreaks": "LF",
   "validateIndentation": 2,
   "requireSpaceAfterLineComment": true
 }


### PR DESCRIPTION
Showing a lot of errors on Windows. I have tryed to change settigns for WebStrom, but it doesn't help. Anyway, git checks this on commiting and reformat code if it's nedeed. That's why I get error on local machine, but tests in Travis finishes without errors.
